### PR TITLE
Serialize storage/DB and singletons.

### DIFF
--- a/src/orion/client/__init__.py
+++ b/src/orion/client/__init__.py
@@ -240,7 +240,7 @@ def build_experiment(
 
     producer = Producer(experiment, max_idle_time)
 
-    return ExperimentClient(experiment, producer, heartbeat, storage)
+    return ExperimentClient(experiment, producer, heartbeat)
 
 
 def get_experiment(name, version=None, mode="r", storage=None):
@@ -275,7 +275,7 @@ def get_experiment(name, version=None, mode="r", storage=None):
     setup_storage(storage)
     assert mode in set("rw")
     experiment = experiment_builder.load(name, version, mode)
-    return ExperimentClient(experiment, None, storage=storage)
+    return ExperimentClient(experiment, None)
 
 
 def workon(

--- a/src/orion/core/io/database/mongodb.py
+++ b/src/orion/core/io/database/mongodb.py
@@ -121,6 +121,20 @@ class MongoDB(AbstractDB):
             authSource=name,
         )
 
+    def __getstate__(self):
+        state = dict()
+        for key in ["host", "name", "port", "username", "password", "options"]:
+            state[key] = getattr(self, key)
+
+        return state
+
+    def __setstate__(self, state):
+        for key in ["host", "name", "port", "username", "password", "options"]:
+            print(key, state[key])
+            setattr(self, key, state[key])
+        self.uri = None
+        self.initiate_connection()
+
     @mongodb_exception_wrapper
     def initiate_connection(self):
         """Connect to database, unless MongoDB `is_connected`.

--- a/tests/functional/algos/test_algos.py
+++ b/tests/functional/algos/test_algos.py
@@ -199,7 +199,7 @@ def test_with_multidim(algorithm):
 def test_with_evc(algorithm):
     """Test a scenario where algos are warm-started with EVC."""
 
-    with OrionState(storage={"type": "legacy", "database": {"type": "EphemeralDB"}}):
+    with OrionState(storage={"type": "legacy", "database": {"type": "PickledDB"}}):
         base_exp = create_experiment(
             name="exp",
             space=space_with_fidelity,
@@ -252,59 +252,56 @@ def test_with_evc(algorithm):
 @pytest.mark.parametrize(
     "algorithm", algorithm_configs.values(), ids=list(algorithm_configs.keys())
 )
-def test_parallel_workers(algorithm, tmp_path):
+def test_parallel_workers(algorithm):
     """Test parallel execution with joblib"""
-    pickle_host = str(tmp_path / "db.pkl")
+    with OrionState() as cfg:  # Using PickledDB
 
-    name = "{}_exp".format(list(algorithm.keys())[0])
+        name = "{}_exp".format(list(algorithm.keys())[0])
 
-    storage = {"type": "legacy", "database": {"type": "PickledDB", "host": pickle_host}}
-    base_exp = create_experiment(
-        name=name,
-        space=space_with_fidelity,
-        algorithms=algorithm_configs["random"],
-        storage=storage,
-    )
-    base_exp.workon(rosenbrock, max_trials=10)
+        base_exp = create_experiment(
+            name=name,
+            space=space_with_fidelity,
+            algorithms=algorithm_configs["random"],
+        )
+        base_exp.workon(rosenbrock, max_trials=10)
 
-    exp = create_experiment(
-        name=name,
-        space=space_with_fidelity,
-        algorithms=algorithm,
-        branching={"branch_from": name},
-        storage=storage,
-    )
+        exp = create_experiment(
+            name=name,
+            space=space_with_fidelity,
+            algorithms=algorithm,
+            branching={"branch_from": name},
+        )
 
-    assert exp.version == 2
+        assert exp.version == 2
 
-    exp.workon(rosenbrock, max_trials=30, n_workers=2)
+        exp.workon(rosenbrock, max_trials=30, n_workers=2)
 
-    assert exp.configuration["algorithms"] == algorithm
+        assert exp.configuration["algorithms"] == algorithm
 
-    trials = exp.fetch_trials(with_evc_tree=False)
-    assert len(trials) >= 20
+        trials = exp.fetch_trials(with_evc_tree=False)
+        assert len(trials) >= 20
 
-    trials_with_evc = exp.fetch_trials(with_evc_tree=True)
-    assert len(trials_with_evc) >= 30
-    assert len(trials_with_evc) - len(trials) == 10
+        trials_with_evc = exp.fetch_trials(with_evc_tree=True)
+        assert len(trials_with_evc) >= 30
+        assert len(trials_with_evc) - len(trials) == 10
 
-    completed_trials = [
-        trial for trial in trials_with_evc if trial.status == "completed"
-    ]
-    assert 30 <= len(completed_trials) <= 30 + 2
+        completed_trials = [
+            trial for trial in trials_with_evc if trial.status == "completed"
+        ]
+        assert 30 <= len(completed_trials) <= 30 + 2
 
-    results = [trial.objective.value for trial in completed_trials]
-    best_trial = next(
-        iter(sorted(completed_trials, key=lambda trial: trial.objective.value))
-    )
+        results = [trial.objective.value for trial in completed_trials]
+        best_trial = next(
+            iter(sorted(completed_trials, key=lambda trial: trial.objective.value))
+        )
 
-    assert best_trial.objective.name == "objective"
-    assert abs(best_trial.objective.value - 23.4) < 1e-5
-    assert len(best_trial.params) == 2
-    fidelity = best_trial._params[0]
-    assert fidelity.name == "noise"
-    assert fidelity.type == "fidelity"
-    assert fidelity.value == 10
-    param = best_trial._params[1]
-    assert param.name == "x"
-    assert param.type == "real"
+        assert best_trial.objective.name == "objective"
+        assert abs(best_trial.objective.value - 23.4) < 1e-5
+        assert len(best_trial.params) == 2
+        fidelity = best_trial._params[0]
+        assert fidelity.name == "noise"
+        assert fidelity.type == "fidelity"
+        assert fidelity.value == 10
+        param = best_trial._params[1]
+        assert param.name == "x"
+        assert param.type == "real"

--- a/tests/unittests/core/database/test_database.py
+++ b/tests/unittests/core/database/test_database.py
@@ -3,6 +3,7 @@
 """Collection of tests for :mod:`orion.core.io.database.pickleddb`."""
 import os
 from datetime import datetime
+import pickle
 
 import pytest
 
@@ -718,3 +719,13 @@ class TestDropIndex(object):
         assert orion_db.index_information("experiments") == index_information
         orion_db.drop_index("experiments", stored_keys)
         assert orion_db.index_information("experiments") == {"_id_": True}
+
+
+@insert_test_collection
+def test_serializable(orion_db):
+    serialized = pickle.dumps(orion_db)
+    deserialized = pickle.loads(serialized)
+    assert len(orion_db.read("test_collection", {})) > 0
+    assert orion_db.read("test_collection", {}) == deserialized.read(
+        "test_collection", {}
+    )

--- a/tests/unittests/core/worker/test_experiment.py
+++ b/tests/unittests/core/worker/test_experiment.py
@@ -553,22 +553,17 @@ def test_experiment_pickleable():
 
     with OrionState(trials=generate_trials(["new"])) as cfg:
         exp = Experiment("supernaekei", mode="x")
+        exp._id = cfg.trials[0]["experiment"]
 
         exp_trials = exp.fetch_trials()
+
+        assert len(exp_trials) > 0
 
         exp_bytes = pickle.dumps(exp)
 
         new_exp = pickle.loads(exp_bytes)
 
-        with pytest.raises(AttributeError) as exc:
-            new_exp.fetch_trials()
-        assert exc.match(f"_storage")
-
-        new_exp._storage = get_storage()
-
-        new_exp_trials = new_exp.fetch_trials()
-
-        assert new_exp_trials == exp_trials
+        assert [trial.to_dict() for trial in exp_trials] == [trial.to_dict() for trial in new_exp.fetch_trials()]
 
 
 read_only_methods = [

--- a/tests/unittests/storage/test_storage.py
+++ b/tests/unittests/storage/test_storage.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 import logging
 import time
+import pickle
 
 import pytest
 
@@ -815,3 +816,13 @@ class TestStorage:
                 assert (
                     trial3.heartbeat is None
                 ), "Legacy does not update trials with a status different from reserved"
+
+    def test_serializable(self, storage):
+        """Test storage can be serialized"""
+        with OrionState(
+            experiments=[base_experiment], trials=generate_trials(), storage=storage
+        ) as cfg:
+            storage = cfg.storage()
+            serialized = pickle.dumps(storage)
+            deserialized = pickle.loads(serialized)
+            assert storage.fetch_experiments({}) == deserialized.fetch_experiments({})


### PR DESCRIPTION
## Serialize storage singletion when pickling EXP
There are many calls to `get_storage` in the code base that requires the
singletons to be set. When serializing the experiment client to run
multiple workers in parallel the singletons are not accessible in the other
workers. We need to serialize them and reinstate them when deserializing.

This is horribly messy but is required due to over-reliance on
`get_storage()`. This is a bad design and we should get rid of it. See
issue Epistimio#606.